### PR TITLE
Removes answer from one quiz question cell

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -217,7 +217,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Q1 = 38.814 Q3 = 40.812 # Your answer here "
+    "# Your answer here "
    ]
   },
   {


### PR DESCRIPTION
The second to last question of the quiz has the answer to finding the upper and lower quartiles. I assume that should just read "Your answer here". Thanks!